### PR TITLE
Allow emails with only cc or bcc fields to go send

### DIFF
--- a/Sources/VaporSMTPKit/VaporSMTPKit.swift
+++ b/Sources/VaporSMTPKit/VaporSMTPKit.swift
@@ -32,7 +32,7 @@ extension Application {
             mail.cc = mail.cc.filter(filterMailAddress)
             mail.bcc = mail.bcc.filter(filterMailAddress)
             
-            if mail.to.isEmpty {
+            if mail.to.isEmpty && mail.cc.isEmpty && mail.bcc.isEmpty {
                 return nil
             }
             


### PR DESCRIPTION
Currently an email has to have the `to` field filled out to work correctly. This isn't always feasible in all workflows and emails with addresses in `cc` or `bcc` fields are also valid.